### PR TITLE
3D phase diagram

### DIFF
--- a/code/phase_diagram.ipynb
+++ b/code/phase_diagram.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ca_lecture_hall_model import Grid\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# function to get the amount of gossipers of multiple simulations\n",
+    "def run_multiple_simulations_for_phase_diagram(size, density, spread_threshold, steps, no_simulations):\n",
+    "    results = {\n",
+    "        \"size\": size,\n",
+    "        \"density\": density,\n",
+    "        \"spread_threshold\": spread_threshold,\n",
+    "        \"steps\": steps,\n",
+    "        \"simulation_outcomes\": [],\n",
+    "    }\n",
+    "\n",
+    "    for i in range(no_simulations):\n",
+    "\n",
+    "        g = Grid(size, density, spread_threshold)\n",
+    "        g.initialize_board()\n",
+    "        \n",
+    "        _, status_counts = g.run_simulation(steps)\n",
+    "        \n",
+    "        # only the final number of GOSSIP_SPREADERS from status_counts for phase diagram\n",
+    "        gossip_spreaders = status_counts[\"GOSSIP_SPREADER\"][-1]\n",
+    "        results[\"simulation_outcomes\"].append(gossip_spreaders)\n",
+    "\n",
+    "    return results\n",
+    "\n",
+    "# function to plot the 3D phase diagram\n",
+    "def plot_phase_diagram_3D(size, steps, no_simulations):\n",
+    "    \"\"\"\n",
+    "    Plots the count of the GOSSIP_SPREADERS against density and spreading threshold as a 3D plot.\n",
+    "\n",
+    "    Parameters:\n",
+    "        size (int): Size of the grid.\n",
+    "        steps (int): Number of steps in the simulation.\n",
+    "        no_simulations (int): Number of simulations per parameter combination.\n",
+    "    \"\"\"\n",
+    "    # range of densities and spreading thresholds\n",
+    "    densities = np.linspace(0, 1, 10)\n",
+    "    spread_thresholds = np.linspace(0, 1, 10)\n",
+    "\n",
+    "    spreader_counts = np.zeros((len(densities), len(spread_thresholds)))\n",
+    "\n",
+    "    for i, spread_threshold in enumerate(spread_thresholds):\n",
+    "        for j, density in enumerate(densities):\n",
+    "            results = run_multiple_simulations_for_phase_diagram(size, density, spread_threshold, steps, no_simulations)\n",
+    "\n",
+    "            # average number of GOSSIP_SPREADERS across simulations\n",
+    "            average_spreaders = np.mean(results[\"simulation_outcomes\"])\n",
+    "            # print(f\"Average GOSSIP_SPREADERS for density={density:.2f}, spread_threshold={spread_threshold:.2f}: {average_spreaders}\\n\") # print statements for checking\n",
+    "            spreader_counts[j, i] = average_spreaders # used for Z\n",
+    "\n",
+    "    # 3D plot\n",
+    "    X, Y = np.meshgrid(spread_thresholds, densities)\n",
+    "    Z = spreader_counts\n",
+    "    fig = plt.figure(figsize=(10, 10))\n",
+    "    ax = fig.add_subplot(projection='3d')\n",
+    "    surface = ax.plot_surface(X, Y, Z, cmap='coolwarm')\n",
+    "    ax.set_xlabel('Spreading Threshold')\n",
+    "    ax.set_ylabel('Density')\n",
+    "    ax.set_zlabel('Average Amount of Gossip Spreaders')\n",
+    "    ax.set_title('Phase Diagram of Gossip Spreaders against Density and Spreading Threshold')\n",
+    "    fig.colorbar(surface, ax=ax, shrink=0.6, aspect=10)\n",
+    "    plt.show()\n",
+    "\n",
+    "plot_phase_diagram_3D(size=20, steps=20, no_simulations=10)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I added a 3D phase plot for the amount of GOSSIP_SPREADERS against both the density and spread_threshold. 

I thought that this was the most easy way to understand the graph. 

The function "run_multiple_simulations_for_phase_diagram" can now only be used for the phase diagram since it only returns the amount of GOSSIP_SPREADERS, if needed, i could make it more general.

