### PR TITLE
Fix: run_simulation function needs to take in a copy of the grid

### DIFF
--- a/code/simulation.py
+++ b/code/simulation.py
@@ -20,7 +20,7 @@ def run_simulation(grid, steps=1000):
     assert isinstance(steps, int), f"steps must be an integer, got {type(steps)}"
     assert steps > 0, f"steps must be greater than 0, got {steps}"
 
-    all_grids = [grid]
+    all_grids = [copy.deepcopy(grid)]
 
     same = 0
     prev_grid = None
@@ -42,7 +42,7 @@ def run_simulation(grid, steps=1000):
         grid.update_grid()
 
         prev_grid = current_grid
-        all_grids.append(grid)
+        all_grids.append(copy.deepcopy(grid))
 
     return all_grids
 


### PR DESCRIPTION
Without the change, we were updating all the grids in the all_grids array, so in the end we returned a list of grids that were all the same, equal to the final grid